### PR TITLE
Disable nginx version tokens

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,6 +7,7 @@ pid /tmp/nginx.pid;
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    server_tokens off;
 
     server {
         listen 80;


### PR DESCRIPTION
## Summary
- keep `nginx` from exposing its version

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `sudo nginx -c /workspace/eb-due/nginx.conf -t`
- `sudo nginx -c /workspace/eb-due/nginx.conf`
- `curl -I http://localhost`

------
https://chatgpt.com/codex/tasks/task_e_6868ddb0c7f88328a4b93f34e376f204