### PR TITLE
Add dockerignore files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Exclude dependencies and build output
+node_modules
+.pnpm-store
+dist
+build
+.next
+out
+
+# Logs
+*.log
+logs
+
+# Backend source not needed for frontend image
+backend
+
+# Local scripts
+start-all.sh
+install-coolify.sh
+debug-coolify.sh
+
+# VCS
+.git

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+# Exclude dependencies and build output
+node_modules
+dist
+build
+
+# Logs
+*.log
+logs
+
+# Test files
+tests
+
+# Local scripts
+*.sh
+
+# VCS
+.git


### PR DESCRIPTION
## Summary
- add `.dockerignore` at project root to exclude unnecessary files from frontend build context
- add `.dockerignore` in `backend` to slim backend build context

## Testing
- `npm install` in `backend`
- `npm test` *(fails: cannot find jest typings)*

------
https://chatgpt.com/codex/tasks/task_e_6868ddaeab748328a02885a720b3df31